### PR TITLE
HAL support

### DIFF
--- a/hypermedia.go
+++ b/hypermedia.go
@@ -98,7 +98,11 @@ func (r *ReflectHypermediaResource) fillRelation(t reflect.Type, v reflect.Value
 	}
 
 	hl := v.Field(index).Interface().(Hyperlink)
-	r.rels[f.Name] = hl
+	name := f.Name
+	if rel := f.Tag.Get("rel"); len(rel) > 0 {
+		name = rel
+	}
+	r.rels[name] = hl
 }
 
 var hyperlinkType = reflect.TypeOf(Hyperlink("foo"))

--- a/hypermedia.go
+++ b/hypermedia.go
@@ -1,6 +1,7 @@
 package sawyer
 
 import (
+	"fmt"
 	"github.com/jtacoma/uritemplates"
 	"net/url"
 )
@@ -32,4 +33,33 @@ func (l *Hyperlink) Expand(m M) (*url.URL, error) {
 
 func (l *Link) Expand(m M) (*url.URL, error) {
 	return l.Href.Expand(m)
+}
+
+// HypermediaResource describes any REST resource with hypermedia relations.
+type HypermediaResource interface {
+	Rels() map[string]Hyperlink
+	Rel(string, M) (*url.URL, error)
+}
+
+// HALResource is a resource with hypermedia specified as JSON HAL.
+type HALResource struct {
+	Links Links `json:"_links"`
+	rels  map[string]Hyperlink
+}
+
+func (r *HALResource) Rels() map[string]Hyperlink {
+	if r.rels == nil {
+		r.rels = make(map[string]Hyperlink)
+		for name, link := range r.Links {
+			r.rels[name] = link.Href
+		}
+	}
+	return r.rels
+}
+
+func (r *HALResource) Rel(name string, m M) (*url.URL, error) {
+	if rel, ok := r.Rels()[name]; ok {
+		return rel.Expand(m)
+	}
+	return nil, fmt.Errorf("No %s relation found", name)
 }

--- a/hypermedia.go
+++ b/hypermedia.go
@@ -65,7 +65,7 @@ func (r *HALResource) Rels() Relations {
 	return r.rels
 }
 
-func HALDecoder(res HypermediaResource) Relations {
+func HypermediaDecoder(res HypermediaResource) Relations {
 	return res.Rels()
 }
 

--- a/hypermedia.go
+++ b/hypermedia.go
@@ -66,14 +66,15 @@ func (r *HALResource) Rel(name string, m M) (*url.URL, error) {
 }
 
 type ReflectHypermediaResource struct {
-	rels map[string]Hyperlink
+	Resource interface{}
+	rels     map[string]Hyperlink
 }
 
-func (r *ReflectHypermediaResource) Rels(resource interface{}) map[string]Hyperlink {
+func (r *ReflectHypermediaResource) Rels() map[string]Hyperlink {
 	if r.rels == nil {
 		r.rels = make(map[string]Hyperlink)
-		t := reflect.TypeOf(resource).Elem()
-		v := reflect.ValueOf(resource).Elem()
+		t := reflect.TypeOf(r.Resource).Elem()
+		v := reflect.ValueOf(r.Resource).Elem()
 		fieldlen := t.NumField()
 		for i := 0; i < fieldlen; i++ {
 			r.fillRelation(t, v, i)
@@ -82,8 +83,8 @@ func (r *ReflectHypermediaResource) Rels(resource interface{}) map[string]Hyperl
 	return r.rels
 }
 
-func (r *ReflectHypermediaResource) Rel(resource interface{}, name string, m M) (*url.URL, error) {
-	if rel, ok := r.Rels(resource)[name]; ok {
+func (r *ReflectHypermediaResource) Rel(name string, m M) (*url.URL, error) {
+	if rel, ok := r.Rels()[name]; ok {
 		return rel.Expand(m)
 	}
 	return nil, fmt.Errorf("No %s relation found", name)

--- a/hypermedia_test.go
+++ b/hypermedia_test.go
@@ -19,11 +19,7 @@ func TestHALRelations(t *testing.T) {
 }`
 
 	user := &HypermediaUser{}
-	dec := json.NewDecoder(bytes.NewBufferString(input))
-	err := dec.Decode(user)
-	if err != nil {
-		t.Fatalf("Errors decoding json: %s", err)
-	}
+	decode(t, input, user)
 
 	rels := user.Rels()
 	assert.Equal(t, 3, len(rels))
@@ -60,11 +56,7 @@ func TestDecode(t *testing.T) {
 }`
 
 	user := &HypermediaUser{}
-	dec := json.NewDecoder(bytes.NewBufferString(input))
-	err := dec.Decode(user)
-	if err != nil {
-		t.Fatalf("Errors decoding json: %s", err)
-	}
+	decode(t, input, user)
 
 	assert.Equal(t, "bob", user.Login)
 	assert.Equal(t, 1, len(user.Links))
@@ -83,6 +75,14 @@ func TestDecode(t *testing.T) {
 		t.Errorf("Errors parsing %s: %s", hl, err)
 	}
 	assert.Equal(t, "/foo/bar/baz", url.String())
+}
+
+func decode(t *testing.T, input string, resource interface{}) {
+	dec := json.NewDecoder(bytes.NewBufferString(input))
+	err := dec.Decode(resource)
+	if err != nil {
+		t.Fatalf("Errors decoding json: %s", err)
+	}
 }
 
 type HypermediaUser struct {

--- a/hypermedia_test.go
+++ b/hypermedia_test.go
@@ -27,7 +27,7 @@ func TestReflectRelations(t *testing.T) {
 	assert.Equal(t, "/self", string(rels["Url"]))
 	assert.Equal(t, "/foo", string(rels["FooUrl"]))
 	assert.Equal(t, "/bar", string(rels["FooBarUrl"]))
-	assert.Equal(t, "/whatevs", string(rels["Whatever"]))
+	assert.Equal(t, "/whatevs", string(rels["whatevs"]))
 
 	rel, err := user.Rel("FooUrl", nil)
 	if err != nil {
@@ -125,7 +125,7 @@ type ReflectedUser struct {
 	Url         Hyperlink
 	FooUrl      Hyperlink
 	FooBarUrl   Hyperlink
-	Whatever    Hyperlink `json:"whatever"`
+	Whatever    Hyperlink `json:"whatever" rel:"whatevs"`
 	HomepageUrl string
 	*ReflectHypermediaResource
 }

--- a/hypermedia_test.go
+++ b/hypermedia_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/bmizerany/assert"
-	"net/url"
 	"testing"
 )
 
@@ -18,7 +17,9 @@ func TestReflectRelations(t *testing.T) {
 , "HomepageUrl": "http://example.com"
 }`
 
-	user := &ReflectedUser{}
+	user := &ReflectedUser{ReflectHypermediaResource: &ReflectHypermediaResource{}}
+	user.ReflectHypermediaResource.Resource = user
+
 	decode(t, input, user)
 
 	rels := user.Rels()
@@ -127,18 +128,4 @@ type ReflectedUser struct {
 	Whatever    Hyperlink `json:"whatever"`
 	HomepageUrl string
 	*ReflectHypermediaResource
-}
-
-func (r *ReflectedUser) Rels() map[string]Hyperlink {
-	if r.ReflectHypermediaResource == nil {
-		r.ReflectHypermediaResource = &ReflectHypermediaResource{}
-	}
-	return r.ReflectHypermediaResource.Rels(r)
-}
-
-func (r *ReflectedUser) Rel(name string, m M) (*url.URL, error) {
-	if r.ReflectHypermediaResource == nil {
-		r.ReflectHypermediaResource = &ReflectHypermediaResource{}
-	}
-	return r.ReflectHypermediaResource.Rel(r, name, m)
 }

--- a/hypermedia_test.go
+++ b/hypermedia_test.go
@@ -17,19 +17,17 @@ func TestReflectRelations(t *testing.T) {
 , "HomepageUrl": "http://example.com"
 }`
 
-	user := &ReflectedUser{ReflectHypermediaResource: &ReflectHypermediaResource{}}
-	user.ReflectHypermediaResource.Resource = user
-
+	user := &ReflectedUser{}
 	decode(t, input, user)
 
-	rels := user.Rels()
+	rels := HyperFieldDecoder(user)
 	assert.Equal(t, 4, len(rels))
 	assert.Equal(t, "/self", string(rels["Url"]))
 	assert.Equal(t, "/foo", string(rels["FooUrl"]))
 	assert.Equal(t, "/bar", string(rels["FooBarUrl"]))
 	assert.Equal(t, "/whatevs", string(rels["whatevs"]))
 
-	rel, err := user.Rel("FooUrl", nil)
+	rel, err := rels.Rel("FooUrl", nil)
 	if err != nil {
 		t.Fatalf("Error getting 'foo' relation: %s", err)
 	}
@@ -50,13 +48,13 @@ func TestHALRelations(t *testing.T) {
 	user := &HypermediaUser{}
 	decode(t, input, user)
 
-	rels := user.Rels()
+	rels := HALDecoder(user)
 	assert.Equal(t, 3, len(rels))
 	assert.Equal(t, "/self", string(rels["self"]))
 	assert.Equal(t, "/foo", string(rels["foo"]))
 	assert.Equal(t, "/bar", string(rels["bar"]))
 
-	rel, err := user.Rel("foo", nil)
+	rel, err := rels.Rel("foo", nil)
 	if err != nil {
 		t.Fatalf("Error getting 'foo' relation: %s", err)
 	}
@@ -127,5 +125,4 @@ type ReflectedUser struct {
 	FooBarUrl   Hyperlink
 	Whatever    Hyperlink `json:"whatever" rel:"whatevs"`
 	HomepageUrl string
-	*ReflectHypermediaResource
 }


### PR DESCRIPTION
Just a quick idea on how we might handle hypermedia parsing.  The GitHub API structs would want to extend HALResource into something that checks HAL first, and then `*Url` properties second.
