### PR TITLE
store the apierror as an interface{} on response.

### DIFF
--- a/response.go
+++ b/response.go
@@ -10,7 +10,9 @@ type Response struct {
 	ResponseError error
 	MediaType     *mediatype.MediaType
 	isApiError    bool
+	ApiError      interface{}
 	BodyClosed    bool
+	errorFunc     func() interface{}
 	*http.Response
 }
 
@@ -23,7 +25,7 @@ func (r *Response) IsError() bool {
 }
 
 func (r *Response) IsApiError() bool {
-	return r.isApiError
+	return r.ApiError != nil
 }
 
 func (r *Response) Error() string {
@@ -33,9 +35,10 @@ func (r *Response) Error() string {
 	return ""
 }
 
-func (r *Response) decode(apierr interface{}, output interface{}) {
+func (r *Response) decode(output interface{}) {
 	if r.isApiError {
-		r.decodeResource(apierr)
+		r.ApiError = r.errorFunc()
+		r.decodeResource(r.ApiError)
 	} else {
 		r.decodeResource(output)
 	}

--- a/sawyer_test.go
+++ b/sawyer_test.go
@@ -47,7 +47,7 @@ func TestResolveWithNoHeader(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	req, _ := client.NewRequest("", nil)
+	req, _ := client.NewRequest("")
 	assert.Equal(t, 0, len(req.Header))
 
 	req.Header.Set("Cache-Control", "private")
@@ -62,7 +62,7 @@ func TestResolveWithHeader(t *testing.T) {
 	}
 	client.Header.Set("Cache-Control", "private")
 
-	req, _ := client.NewRequest("", nil)
+	req, _ := client.NewRequest("")
 	assert.Equal(t, 1, len(req.Header))
 	assert.Equal(t, "private", req.Header.Get("Cache-Control"))
 }


### PR DESCRIPTION
This lets you set the error type on the client, and let the client create the error for decoding on each non-successful request.
