### PR TITLE
Adjust Hyperlink#Expand to accept map[string]interface{}

### DIFF
--- a/hypermedia.go
+++ b/hypermedia.go
@@ -15,10 +15,7 @@ type Link struct {
 
 type Hyperlink string
 
-// uri template map
-type M map[string]interface{}
-
-func (l *Hyperlink) Expand(m M) (*url.URL, error) {
+func (l *Hyperlink) Expand(m map[string]interface{}) (*url.URL, error) {
 	template, err := uritemplates.Parse(string(*l))
 	if err != nil {
 		return nil, err
@@ -32,13 +29,13 @@ func (l *Hyperlink) Expand(m M) (*url.URL, error) {
 	return url.ParseRequestURI(expanded)
 }
 
-func (l *Link) Expand(m M) (*url.URL, error) {
+func (l *Link) Expand(m map[string]interface{}) (*url.URL, error) {
 	return l.Href.Expand(m)
 }
 
 type Relations map[string]Hyperlink
 
-func (h Relations) Rel(name string, m M) (*url.URL, error) {
+func (h Relations) Rel(name string, m map[string]interface{}) (*url.URL, error) {
 	if rel, ok := h[name]; ok {
 		return rel.Expand(m)
 	}

--- a/hypermedia_test.go
+++ b/hypermedia_test.go
@@ -63,7 +63,7 @@ func TestHALRelations(t *testing.T) {
 
 func TestExpand(t *testing.T) {
 	link := Hyperlink("/foo/bar{/arg}")
-	u, _ := link.Expand(M{"arg": "baz", "foo": "bar"})
+	u, _ := link.Expand(map[string]interface{}{"arg": "baz", "foo": "bar"})
 	assert.Equal(t, "/foo/bar/baz", u.String())
 }
 
@@ -89,7 +89,7 @@ func TestDecode(t *testing.T) {
 	assert.Equal(t, 1, len(user.Links))
 
 	hl := user.Url
-	url, err := hl.Expand(M{"arg": "baz"})
+	url, err := hl.Expand(map[string]interface{}{"arg": "baz"})
 	if err != nil {
 		t.Errorf("Errors parsing %s: %s", hl, err)
 	}
@@ -97,7 +97,7 @@ func TestDecode(t *testing.T) {
 	assert.Equal(t, "/foo/bar/baz", url.String())
 
 	hl = user.Links["self"].Href
-	url, err = hl.Expand(M{"arg": "baz"})
+	url, err = hl.Expand(map[string]interface{}{"arg": "baz"})
 	if err != nil {
 		t.Errorf("Errors parsing %s: %s", hl, err)
 	}


### PR DESCRIPTION
Client code can now define

``` go
type M map[string]interface{}
```

to pass on to sawyer, instead of deep cloning octokit.M to sawyer.M.
