### PR TITLE
Fix test failure due to M type conversion.

### DIFF
--- a/hypermedia/hypermedia.go
+++ b/hypermedia/hypermedia.go
@@ -23,7 +23,12 @@ func (l Hyperlink) Expand(m M) (*url.URL, error) {
 		return nil, err
 	}
 
-	expanded, err := template.Expand(m)
+	mm := make(map[string]interface{})
+	for k, v := range m {
+		mm[k] = v
+	}
+
+	expanded, err := template.Expand(mm)
 	if err != nil {
 		return nil, err
 	}

--- a/hypermedia/hypermedia.go
+++ b/hypermedia/hypermedia.go
@@ -23,7 +23,11 @@ func (l Hyperlink) Expand(m M) (*url.URL, error) {
 		return nil, err
 	}
 
-	mm := make(map[string]interface{})
+	// clone M to map[string]interface{}
+	// if we don't do this type assertion will
+	// fail on jtacoma/uritemplates
+	// see https://github.com/jtacoma/uritemplates/blob/master/uritemplates.go#L189
+	mm := make(map[string]interface{}, len(m))
 	for k, v := range m {
 		mm[k] = v
 	}

--- a/hypermedia/hypermedia.go
+++ b/hypermedia/hypermedia.go
@@ -17,8 +17,8 @@ type M map[string]interface{}
 
 type Hyperlink string
 
-func (l *Hyperlink) Expand(m M) (*url.URL, error) {
-	template, err := uritemplates.Parse(string(*l))
+func (l Hyperlink) Expand(m M) (*url.URL, error) {
+	template, err := uritemplates.Parse(string(l))
 	if err != nil {
 		return nil, err
 	}

--- a/hypermedia/hypermedia_test.go
+++ b/hypermedia/hypermedia_test.go
@@ -55,21 +55,21 @@ func TestHALRelations(t *testing.T) {
 	assert.Equal(t, "/bar", string(rels["bar"]))
 
 	rel, err := rels.Rel("foo", nil)
-	if err != nil {
-		t.Fatalf("Error getting 'foo' relation: %s", err)
-	}
+	assert.Equal(t, nil, err)
 	assert.Equal(t, "/foo", rel.Path)
 }
 
 func TestExpand(t *testing.T) {
 	link := Hyperlink("/foo/bar{/arg}")
-	u, _ := link.Expand(M{"arg": "baz", "foo": "bar"})
+	u, err := link.Expand(M{"arg": "baz", "foo": "bar"})
+	assert.Equal(t, nil, err)
 	assert.Equal(t, "/foo/bar/baz", u.String())
 }
 
 func TestExpandNil(t *testing.T) {
 	link := Hyperlink("/foo/bar{/arg}")
-	u, _ := link.Expand(nil)
+	u, err := link.Expand(nil)
+	assert.Equal(t, nil, err)
 	assert.Equal(t, "/foo/bar", u.String())
 }
 

--- a/hypermedia/hypermedia_test.go
+++ b/hypermedia/hypermedia_test.go
@@ -28,9 +28,7 @@ func TestReflectRelations(t *testing.T) {
 	assert.Equal(t, "/whatevs", string(rels["whatevs"]))
 
 	rel, err := rels.Rel("FooUrl", nil)
-	if err != nil {
-		t.Fatalf("Error getting 'foo' relation: %s", err)
-	}
+	assert.Equal(t, nil, err)
 	assert.Equal(t, "/foo", rel.Path)
 }
 


### PR DESCRIPTION
Discovered this through Travis: https://travis-ci.org/octokit/go-octokit.

I may have an older version of jtacoma/uritemplates locally which caused the tests to pass
