### PR TITLE
Allow to parse relative url templates.

### DIFF
--- a/gopack.config
+++ b/gopack.config
@@ -1,3 +1,9 @@
+repo = "github.com/lostisland/go-sawyer"
+
 [deps.uritemplates]
 import = "github.com/jtacoma/uritemplates"
 commit = "2b6fc855d3a722bc0e5525ae50bb3c10703c5450"
+
+[deps.assert]
+import = "github.com/bmizerany/assert"
+commit = "e17e99893cb6509f428e1728281c2ad60a6b31e3"

--- a/hypermedia/hypermedia.go
+++ b/hypermedia/hypermedia.go
@@ -34,7 +34,7 @@ func (l Hyperlink) Expand(m M) (*url.URL, error) {
 		return nil, err
 	}
 
-	return url.ParseRequestURI(expanded)
+	return url.Parse(expanded)
 }
 
 // M represents a map of values to expand a Hyperlink.

--- a/hypermedia/hypermedia_test.go
+++ b/hypermedia/hypermedia_test.go
@@ -57,11 +57,18 @@ func TestHALRelations(t *testing.T) {
 	assert.Equal(t, "/foo", rel.Path)
 }
 
-func TestExpand(t *testing.T) {
+func TestExpandAbsoluteUrls(t *testing.T) {
 	link := Hyperlink("/foo/bar{/arg}")
 	u, err := link.Expand(M{"arg": "baz", "foo": "bar"})
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "/foo/bar/baz", u.String())
+}
+
+func TestExpandRelativePaths(t *testing.T) {
+	link := Hyperlink("foo/bar{/arg}")
+	u, err := link.Expand(M{"arg": "baz", "foo": "bar"})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "foo/bar/baz", u.String())
 }
 
 func TestExpandNil(t *testing.T) {

--- a/sawyer_test.go
+++ b/sawyer_test.go
@@ -2,6 +2,7 @@ package sawyer
 
 import (
 	"github.com/bmizerany/assert"
+	"github.com/lostisland/go-sawyer/hypermedia"
 	"net/url"
 	"testing"
 )
@@ -111,4 +112,20 @@ func TestResolveClientRelativeReference(t *testing.T) {
 	}
 
 	assert.Equal(t, "http://github.enterprise.com/api/v3/users", u)
+}
+
+func TestResolveClientRelativeHyperlink(t *testing.T) {
+	client, err := NewFromString("http://github.enterprise.com/api/v3/", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	link := hypermedia.Hyperlink("repos/{repo}")
+	expanded, err := link.Expand(hypermedia.M{"repo": "foo"})
+
+	u, err := client.ResolveReferenceString(expanded.String())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	assert.Equal(t, "http://github.enterprise.com/api/v3/repos/foo", u)
 }

--- a/sawyer_test.go
+++ b/sawyer_test.go
@@ -99,3 +99,16 @@ func TestResolveClientQueryWithClientQuery(t *testing.T) {
 
 	assert.Equal(t, "http://api.github.com/foo?a=1&b=2&c=3&d=4", u)
 }
+
+func TestResolveClientRelativeReference(t *testing.T) {
+	client, err := NewFromString("http://github.enterprise.com/api/v3/", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	u, err := client.ResolveReferenceString("users")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	assert.Equal(t, "http://github.enterprise.com/api/v3/users", u)
+}


### PR DESCRIPTION
Otherwise Client.ResolveReference will override part of our urls when the
endpoints contain path.

The problem is more evident when working with GitHub Enterprise, where the api path is `/api/v3`.
Sawyer removes that part of the path when go-octokit tries to create hyperlinks.
