### PR TITLE
Functional rels

### DIFF
--- a/hypermedia/hal.go
+++ b/hypermedia/hal.go
@@ -12,7 +12,7 @@ type HALResource struct {
 	rels  Relations
 }
 
-func (r *HALResource) FillRels(rels Relations) {
+func (r *HALResource) HypermediaRels(rels Relations) {
 	if r.Links == nil {
 		return
 	}

--- a/hypermedia/hyperfields.go
+++ b/hypermedia/hyperfields.go
@@ -4,6 +4,10 @@ import (
 	"reflect"
 )
 
+type HyperfieldResource interface {
+	HyperfieldRels()
+}
+
 // The HyperFieldRelations gets link relations from a resource by reflecting on
 // its Hyperlink properties.  The relation name is taken either from the name
 // of the field, or a "rel" struct tag.

--- a/hypermedia/hypermedia.go
+++ b/hypermedia/hypermedia.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Rels returns a new Relations object.
-func Rels() Relations {
+func NewRels() Relations {
 	return Relations{}
 }
 

--- a/hypermedia/hypermedia.go
+++ b/hypermedia/hypermedia.go
@@ -13,6 +13,20 @@ func NewRels() Relations {
 	return Relations{}
 }
 
+func Rels(resource interface{}) Relations {
+	rels := NewRels()
+
+	if hypermediaRel, ok := resource.(HypermediaResource); ok {
+		hypermediaRel.HypermediaRels(rels)
+	}
+
+	if hypermediaRel, ok := resource.(HyperfieldResource); ok {
+		HyperFieldRelations(hypermediaRel, rels)
+	}
+
+	return rels
+}
+
 // Hyperlink is a string url.  If it is a uri template, it can be converted to
 // a full URL with Expand().
 type Hyperlink string
@@ -57,5 +71,5 @@ func (h Relations) Rel(name string, m M) (*url.URL, error) {
 
 // A HypermediaResource has link relations for next actions of a resource.
 type HypermediaResource interface {
-	FillRels(Relations)
+	HypermediaRels(Relations)
 }

--- a/hypermedia/hypermedia.go
+++ b/hypermedia/hypermedia.go
@@ -16,12 +16,12 @@ func NewRels() Relations {
 func Rels(resource interface{}) Relations {
 	rels := NewRels()
 
-	if hypermediaRel, ok := resource.(HypermediaResource); ok {
-		hypermediaRel.HypermediaRels(rels)
-	}
-
 	if hypermediaRel, ok := resource.(HyperfieldResource); ok {
 		HyperFieldRelations(hypermediaRel, rels)
+	}
+
+	if hypermediaRel, ok := resource.(HypermediaResource); ok {
+		hypermediaRel.HypermediaRels(rels)
 	}
 
 	return rels

--- a/hypermedia/hypermedia_test.go
+++ b/hypermedia/hypermedia_test.go
@@ -46,8 +46,7 @@ func TestHALRelations(t *testing.T) {
 	user := &HypermediaUser{}
 	decode(t, input, user)
 
-	rels := NewRels()
-	user.FillRels(rels)
+	rels := Rels(user)
 	assert.Equal(t, 3, len(rels))
 	assert.Equal(t, "/self", string(rels["self"]))
 	assert.Equal(t, "/foo", string(rels["foo"]))

--- a/hypermedia/hypermedia_test.go
+++ b/hypermedia/hypermedia_test.go
@@ -46,7 +46,7 @@ func TestHALRelations(t *testing.T) {
 	user := &HypermediaUser{}
 	decode(t, input, user)
 
-	rels := Rels()
+	rels := NewRels()
 	user.FillRels(rels)
 	assert.Equal(t, 3, len(rels))
 	assert.Equal(t, "/self", string(rels["self"]))

--- a/request.go
+++ b/request.go
@@ -47,7 +47,7 @@ func (r *Request) Do(method string) *Response {
 		MediaType:  mtype,
 		BodyClosed: false,
 		Response:   httpres,
-		Rels:       hypermedia.HyperHeaderRelations(httpres.Header, nil),
+		rels:       hypermedia.HyperHeaderRelations(httpres.Header, nil),
 		isApiError: UseApiError(httpres.StatusCode),
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -47,23 +47,23 @@ func TestSuccessfulGet(t *testing.T) {
 	assert.Equal(t, false, res.IsError())
 	assert.Equal(t, false, res.IsApiError())
 
-	assert.Equal(t, 2, len(res.Rels))
-	assert.Equal(t, "https://api.github.com/user/repos?page=3&per_page=100", string(res.Rels["next"]))
-	assert.Equal(t, "https://api.github.com/user/repos?page=50&per_page=100", string(res.Rels["last"]))
+	rels := hypermedia.Rels(res)
+	assert.Equal(t, 2, len(rels))
+	assert.Equal(t, "https://api.github.com/user/repos?page=3&per_page=100", string(rels["next"]))
+	assert.Equal(t, "https://api.github.com/user/repos?page=50&per_page=100", string(rels["last"]))
 
 	assert.Equal(t, nil, res.Decode(user))
 	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, user.Id)
 	assert.Equal(t, "sawyer", user.Login)
 
-	assert.Equal(t, 7, len(res.Rels))
-	assert.Equal(t, "https://api.github.com/user/repos?page=3&per_page=100", string(res.Rels["next"]))
-	assert.Equal(t, "https://api.github.com/user/repos?page=50&per_page=100", string(res.Rels["last"]))
-	assert.Equal(t, "/hal/self", string(res.Rels["self"]))
-	assert.Equal(t, "/hal/foo", string(res.Rels["foo"]))
-	assert.Equal(t, "/hal/boom", string(res.Rels["boom"]))
-	assert.Equal(t, "/field/whatevs", string(res.Rels["whatevs"]))
-	assert.Equal(t, "/field/self", string(res.Rels["Url"]))
+	userRels := hypermedia.Rels(user)
+	assert.Equal(t, 5, len(userRels))
+	assert.Equal(t, "/hal/self", string(userRels["self"]))
+	assert.Equal(t, "/hal/foo", string(userRels["foo"]))
+	assert.Equal(t, "/hal/boom", string(userRels["boom"]))
+	assert.Equal(t, "/field/whatevs", string(userRels["whatevs"]))
+	assert.Equal(t, "/field/self", string(userRels["Url"]))
 }
 
 func TestSuccessfulGetWithoutOutput(t *testing.T) {
@@ -237,6 +237,8 @@ type TestUser struct {
 	HomepageUrl string               `json:"homepage_url"`
 	*hypermedia.HALResource
 }
+
+func (u *TestUser) HyperfieldRels() {}
 
 type TestError struct {
 	Message string `json:"message"`

--- a/response.go
+++ b/response.go
@@ -12,7 +12,7 @@ type Response struct {
 	MediaType     *mediatype.MediaType
 	isApiError    bool
 	BodyClosed    bool
-	Rels          hypermedia.Relations
+	rels          hypermedia.Relations
 	*http.Response
 }
 
@@ -35,6 +35,12 @@ func (r *Response) Error() string {
 	return ""
 }
 
+func (r *Response) HypermediaRels(rels hypermedia.Relations) {
+	for key, value := range r.rels {
+		rels[key] = value
+	}
+}
+
 func (r *Response) Decode(resource interface{}) error {
 	if r.MediaType == nil {
 		return errors.New("No media type for this response")
@@ -54,32 +60,12 @@ func (r *Response) Decode(resource interface{}) error {
 		r.ResponseError = dec.Decode(resource)
 	}
 
-	if r.ResponseError == nil {
-		r.fillRels(resource)
-	}
-
 	return r.ResponseError
 }
 
 func (r *Response) decode(output interface{}) {
 	if !r.isApiError {
 		r.Decode(output)
-	}
-}
-
-func (r *Response) fillRels(v interface{}) {
-	if v == nil {
-		return
-	}
-
-	if r.Rels == nil {
-		r.Rels = hypermedia.NewRels()
-	}
-
-	hypermedia.HyperFieldRelations(v, r.Rels)
-
-	if hal, ok := v.(hypermedia.HypermediaResource); ok {
-		hal.HypermediaRels(r.Rels)
 	}
 }
 

--- a/response.go
+++ b/response.go
@@ -79,7 +79,7 @@ func (r *Response) fillRels(v interface{}) {
 	hypermedia.HyperFieldRelations(v, r.Rels)
 
 	if hal, ok := v.(hypermedia.HypermediaResource); ok {
-		hal.FillRels(r.Rels)
+		hal.HypermediaRels(r.Rels)
 	}
 }
 

--- a/response.go
+++ b/response.go
@@ -73,7 +73,7 @@ func (r *Response) fillRels(v interface{}) {
 	}
 
 	if r.Rels == nil {
-		r.Rels = hypermedia.Rels()
+		r.Rels = hypermedia.NewRels()
 	}
 
 	hypermedia.HyperFieldRelations(v, r.Rels)


### PR DESCRIPTION
This takes a more functional approach to getting hypermedia relations out of an object.  Check the test changes to see how this affects things.  It should fix the bug with automatically trying to merge the relations of a `[]Collection` into the Response object.

Looking up cached relations could be done with something like (not implemented yet):

``` go
hypermedia.Rels(hypermedia.Cache("/users/1", &User{}))
```

The `hypermedia.Cache` object (not really happy with the name) knows how to check the cache for the relations on the User object.  If it's not cached, make the request, decode it into the given `*User`, and return its Relations.

Thoughts?
