### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ type User struct {
 }
 
 class ApiError struct {
-  Message strign `json:"message"`
+  Message string `json:"message"`
 }
 
 client := sawyer.NewFromString("https://api.github.com")


### PR DESCRIPTION
Now you can just copy paste the code and run it without incident!
